### PR TITLE
Deis request data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In order to run your CloudMine Snippets locally, please follow the below instruc
 
 1. Ensure that all NPM module dependencies are defined in `package.json`. 
 2. Run `npm install` from the root directory to ensure that the dependencies are included into the project. 
-3. Next, run `node index.js` to start the server.
+3. Next, run `npm test` to start the server in local test mode.
 4. Finally, `curl`, `wget`, or use your favorite method of running HTTP commands using the below examples.
 
 #### Obtain a Listing of Available Snippets
@@ -55,7 +55,7 @@ Response:
  
 Request:
 
-`localhost:4545/code/basic`
+`localhost:4545/v1/app/{appid}/run/basic`
 
 Response:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node index.js",
     "postinstall": "",
-    "test": ""
+    "test": "LOCAL_TESTING=true node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor updates to account for changes in node-coderunner. The most important note is that this **should not be merged** until we have the new node-coderunner published to npm. 

I tested by symlinking `node_modules/cloudmine-servercode` to the `deis-request-data` branch of my `node-coderunner` fork. The environment variable set in npm test won't do anything otherwise.

The environment variable piece has not yet been tested on windows (will edit this when I've gotten to it).
